### PR TITLE
[feat] 시작 페이지 마크업

### DIFF
--- a/src/components/Start/index.tsx
+++ b/src/components/Start/index.tsx
@@ -11,8 +11,20 @@ function Start() {
         alt="demo logo"
       />
       <div className={style.buttonContainer}>
-        <button className={style.button}>시작하기</button>
-        <button className={style.button}>로그인</button>
+        <button
+          className={style.button}
+          type="button"
+          aria-label="start button"
+        >
+          시작하기
+        </button>
+        <button
+          className={style.button}
+          type="button"
+          aria-label="login button"
+        >
+          로그인
+        </button>
       </div>
     </div>
   );

--- a/src/components/Start/index.tsx
+++ b/src/components/Start/index.tsx
@@ -1,0 +1,21 @@
+import style from './style.module.scss';
+
+function Start() {
+  return (
+    <div className={style.mainContainer}>
+      <h1 className={style.title}>충북대학교 과팅</h1>
+      <h2 className={style.subTitle}>지금 시작하시겠어요?</h2>
+      <img
+        className={style.mainImage}
+        src="https://www.chungbuk.ac.kr/resource/site/pr/images/contents/cnt1830_img01.jpg"
+        alt="demo logo"
+      />
+      <div className={style.buttonContainer}>
+        <button className={style.button}>시작하기</button>
+        <button className={style.button}>로그인</button>
+      </div>
+    </div>
+  );
+}
+
+export default Start;

--- a/src/components/Start/style.module.scss
+++ b/src/components/Start/style.module.scss
@@ -1,10 +1,12 @@
 .mainContainer {
+  width: 100vw;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
 
   .title {
-    margin-top: 120px;
     font: 40px/53px Nirmala UI;
     letter-spacing: 0px;
     color: #191919;
@@ -19,8 +21,8 @@
 
   .mainImage {
     margin-top: 60px;
-    width: 540px;
-    height: 212px;
+    width: 100vw;
+    max-width: 500px;
   }
 
   .buttonContainer {
@@ -37,9 +39,10 @@
       font: normal normal normal 30px/44px Noto Sans CJK KR;
       letter-spacing: 0px;
       color: #ffffff;
+      cursor: pointer;
 
       &:first-child {
-        margin-top: 120px;
+        margin-top: 100px;
       }
 
       &:nth-child(2) {

--- a/src/components/Start/style.module.scss
+++ b/src/components/Start/style.module.scss
@@ -1,0 +1,50 @@
+.mainContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .title {
+    margin-top: 120px;
+    font: 40px/53px Nirmala UI;
+    letter-spacing: 0px;
+    color: #191919;
+  }
+
+  .subTitle {
+    margin-top: 4px;
+    font: 24px/35px Noto Sans CJK KR;
+    letter-spacing: 0px;
+    color: #191919;
+  }
+
+  .mainImage {
+    margin-top: 60px;
+    width: 540px;
+    height: 212px;
+  }
+
+  .buttonContainer {
+    display: flex;
+    flex-direction: column;
+
+    .button {
+      width: 186px;
+      height: 56px;
+      background: #ff5c66 0% 0% no-repeat padding-box;
+      border-radius: 8px;
+      border: none;
+      text-align: center;
+      font: normal normal normal 30px/44px Noto Sans CJK KR;
+      letter-spacing: 0px;
+      color: #ffffff;
+
+      &:first-child {
+        margin-top: 120px;
+      }
+
+      &:nth-child(2) {
+        margin-top: 14px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 💡 이슈
resolve #7 

## 🤩 개요
디자인을 기반으로 시작 페이지를 마크업했습니다.

## 🧑‍💻 작업 사항
- `components` 디렉토리 안에 `Start` 디렉토리 생성
- `Start` 디렉토리 안에 `index.tsx`, `style.module.scss` 생성
- 충림이 디자인 바탕으로 마크업 코드 작성.

## 📖 참고 사항
- 어도비 Xd에서 추출한 CSS를 바탕으로 적절히 수정하여 사용했습니다.
- 폰트는 적용하지 않았습니다.
- 시작하기, 로그인 버튼은 각 페이지로 리디렉션만 하면 되므로, 나중에 해당 기능을 추가할 계획입니다.

<img width="269" alt="image" src="https://user-images.githubusercontent.com/71015915/156296268-0b8fd577-83e0-471e-a104-5e935d50329a.png">
