### PR TITLE
[feat] 개인 정보 동의 페이지

### DIFF
--- a/src/components/Join/ToS/index.tsx
+++ b/src/components/Join/ToS/index.tsx
@@ -1,0 +1,106 @@
+import style from './style.module.scss';
+import { useForm, Controller } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import ToSSchema from './yup';
+import { IoIosCheckboxOutline, IoIosCheckbox } from 'react-icons/io';
+
+interface TOS {
+  c1: boolean;
+  c2: boolean;
+}
+
+export default function ToS() {
+  const {
+    control,
+    watch,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<TOS>({
+    resolver: yupResolver(ToSSchema),
+  });
+
+  const watchCondition = watch(['c1', 'c2'], {
+    c1: false,
+    c2: false,
+  });
+
+  const onSubmit = (data: TOS) => console.log(data);
+
+  return (
+    <main className={style.tos}>
+      <form className={style.form} onSubmit={handleSubmit(onSubmit)}>
+        <h1>회원가입 약관동의</h1>
+        <section className={style.item}>
+          {!watchCondition[0] ? (
+            <Controller
+              name="c1"
+              control={control}
+              render={({ field }) => (
+                <IoIosCheckboxOutline
+                  className={style.checkbox}
+                  onClick={() => setValue('c1', !watchCondition[0])}
+                  {...field}
+                />
+              )}
+            />
+          ) : (
+            <Controller
+              name="c1"
+              control={control}
+              render={({ field }) => (
+                <IoIosCheckbox
+                  className={style.checkbox}
+                  onClick={() => setValue('c1', !watchCondition[0])}
+                  {...field}
+                />
+              )}
+            />
+          )}
+          <label>이용약관 동의</label>
+          <span>(필수)</span>
+          <span className={style.error}>{errors.c1 && errors.c1?.message}</span>
+          <div className={style.content}>
+            <p>약관 내용</p>
+          </div>
+        </section>
+        <section className={style.item}>
+          {!watchCondition[1] ? (
+            <Controller
+              name="c2"
+              control={control}
+              render={({ field }) => (
+                <IoIosCheckboxOutline
+                  className={style.checkbox}
+                  onClick={() => setValue('c2', !watchCondition[1])}
+                  {...field}
+                />
+              )}
+            />
+          ) : (
+            <Controller
+              name="c2"
+              control={control}
+              render={({ field }) => (
+                <IoIosCheckbox
+                  className={style.checkbox}
+                  onClick={() => setValue('c2', !watchCondition[1])}
+                  {...field}
+                />
+              )}
+            />
+          )}
+          <label>개인정보 수집 및 이용 동의</label>
+          <span>(필수)</span>
+          <span className={style.error}>{errors.c2 && errors.c2?.message}</span>
+          <div className={style.content}>
+            <p>약관내용</p>
+          </div>
+        </section>
+        <button type="submit" className={style.next_btn}>
+          다음
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/components/Join/ToS/index.tsx
+++ b/src/components/Join/ToS/index.tsx
@@ -32,31 +32,25 @@ export default function ToS() {
       <form className={style.form} onSubmit={handleSubmit(onSubmit)}>
         <h1>회원가입 약관동의</h1>
         <section className={style.item}>
-          {!watchCondition[0] ? (
-            <Controller
-              name="c1"
-              control={control}
-              render={({ field }) => (
+          <Controller
+            name="c1"
+            control={control}
+            render={({ field }) =>
+              !watchCondition[0] ? (
                 <IoIosCheckboxOutline
                   className={style.checkbox}
                   onClick={() => setValue('c1', !watchCondition[0])}
                   {...field}
                 />
-              )}
-            />
-          ) : (
-            <Controller
-              name="c1"
-              control={control}
-              render={({ field }) => (
+              ) : (
                 <IoIosCheckbox
                   className={style.checkbox}
                   onClick={() => setValue('c1', !watchCondition[0])}
                   {...field}
                 />
-              )}
-            />
-          )}
+              )
+            }
+          />
           <label>이용약관 동의</label>
           <span>(필수)</span>
           <span className={style.error}>{errors.c1 && errors.c1?.message}</span>
@@ -64,32 +58,27 @@ export default function ToS() {
             <p>약관 내용</p>
           </div>
         </section>
+
         <section className={style.item}>
-          {!watchCondition[1] ? (
-            <Controller
-              name="c2"
-              control={control}
-              render={({ field }) => (
+          <Controller
+            name="c2"
+            control={control}
+            render={({ field }) =>
+              !watchCondition[1] ? (
                 <IoIosCheckboxOutline
                   className={style.checkbox}
                   onClick={() => setValue('c2', !watchCondition[1])}
                   {...field}
                 />
-              )}
-            />
-          ) : (
-            <Controller
-              name="c2"
-              control={control}
-              render={({ field }) => (
+              ) : (
                 <IoIosCheckbox
                   className={style.checkbox}
                   onClick={() => setValue('c2', !watchCondition[1])}
                   {...field}
                 />
-              )}
-            />
-          )}
+              )
+            }
+          />
           <label>개인정보 수집 및 이용 동의</label>
           <span>(필수)</span>
           <span className={style.error}>{errors.c2 && errors.c2?.message}</span>
@@ -97,6 +86,7 @@ export default function ToS() {
             <p>약관내용</p>
           </div>
         </section>
+
         <button type="submit" className={style.next_btn}>
           다음
         </button>

--- a/src/components/Join/ToS/style.module.scss
+++ b/src/components/Join/ToS/style.module.scss
@@ -1,0 +1,55 @@
+@import '../../../styles/_color.scss';
+
+.tos{
+  h1{
+    font-size: 170%;
+    font-weight: 500;
+  }
+  
+  .item{
+    margin: 0 auto;
+    font-weight: 500;
+     
+    .checkbox{
+      width: 15px;
+      height: 15px;
+      margin-right: 5px;
+    }
+    
+    label{
+      margin: 10px 0;
+    }
+    
+    span{
+      color: red;
+      margin: 0 5px;
+
+      &.error{
+        color: orange;
+        font-size: 14px;
+      }
+    }
+    
+    .content{
+      width: 90%;
+      height: 200px;
+      overflow: scroll;
+      border-radius: 5px;
+      box-shadow: 0 0 2.5px 0.2px $gray-400;
+      padding: 10px;
+      color: $gray-600;
+      font-size: 14px;
+      line-height: 120%;
+    }
+  }
+  .next_btn{
+    width: 100%;
+    height: 45px;
+    margin-top: 20px;
+    border: 1px solid $primary;
+    border-radius: 15px;
+    background-color: $primary;
+    color: $white;
+    font-size: 20px;
+  }
+}

--- a/src/components/Join/ToS/yup.tsx
+++ b/src/components/Join/ToS/yup.tsx
@@ -1,0 +1,8 @@
+import * as yup from 'yup';
+
+const ToSSchema = yup.object({
+  condition1: yup.boolean().oneOf([true], '필수 약관에 동의해주세요.'),
+  condition2: yup.boolean().oneOf([true], '필수 약관에 동의해주세요.'),
+});
+
+export default ToSSchema;

--- a/src/components/Join/index.ts
+++ b/src/components/Join/index.ts
@@ -1,2 +1,3 @@
 export { default as BasicInfo } from './BasicJoin';
 export { default as Personality } from './PersonalityJoin';
+export { default as ToS } from './ToS';

--- a/src/components/Join/index.ts
+++ b/src/components/Join/index.ts
@@ -1,3 +1,4 @@
 export { default as BasicInfo } from './BasicJoin';
 export { default as Personality } from './PersonalityJoin';
 export { default as PhoneVerify } from './PhoneVerify';
+export { default as ToS } from './ToS';


### PR DESCRIPTION
## 💡 이슈
resolve #12
feat/i2에서 파생한 브랜치입니다. feat/i2로 셀프 머지한 후  dev로 pr 날리겠습니다.

## 🤩 개요
개인정보 동의 페이지를 제작했습니다. 기본정보 입력 컴포넌트와 병합할 pr입니다.

## 🧑‍💻 작업 사항
- [ ] 이용약관 동의
- [ ] 개인정보 수집 및 이용동의

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요
<img width="443" alt="스크린샷 2022-03-06 오후 7 21 58" src="https://user-images.githubusercontent.com/63364990/156919009-3f228610-e1ce-4e82-9cc4-495713c88d9f.png">
