### PR TITLE
[Feat/i92] 단체 프로필 사진 기능

### DIFF
--- a/src/__mocks__/chat.ts
+++ b/src/__mocks__/chat.ts
@@ -1,3 +1,5 @@
+import { profileList } from './mutiProfile';
+
 export const messageInfoMocks = [
   {
     sender: {
@@ -58,8 +60,7 @@ export const messageInfoMocks = [
 
 export const chatListMocks = [
   {
-    roomImage:
-      'https://data.ygosu.com/editor/attach/20180420/20180420132150_dovqlksp.jpg',
+    roomImage: profileList,
     title:
       '소프트웨어학과 남자 3명 소프트웨어학과 남자 3명소프트웨어학과 남자 3명소프트웨어학과 남자 3명소프트웨어학과 남자 3명',
     content:
@@ -68,24 +69,22 @@ export const chatListMocks = [
     count: '26',
   },
   {
-    roomImage:
-      'https://media.bunjang.co.kr/product/166788639_1_1634025108_w360.jpg',
-    title: '심리학과 여자 4명',
+    roomImage: profileList,
+    title:
+      '심리학과 여자 4명 심리학과 여자 4명 심리학과 여자 4명 심리학과 여자 4명 심리학과 여자 4명 심리학과 여자 4명',
     content: '언제가 좋을까요?',
     time: '오후 2:18',
     count: '38',
   },
   {
-    roomImage:
-      'https://cphoto.asiae.co.kr/listimglink/6/2022022115112252412_1645423882.png',
-    title: '간호학과 여자 3명',
+    roomImage: profileList,
+    title: '간호학과 여자 3명 간호학과 여자 3명',
     content: '안녕하세용',
     time: '오전 1:35',
     count: '5',
   },
   {
-    roomImage:
-      'https://cphoto.asiae.co.kr/listimglink/6/2022022115112252412_1645423882.png',
+    roomImage: profileList,
     title: '화학과 남자 3명',
     content: ':):D',
     time: '오전 3:05',

--- a/src/__mocks__/mutiProfile.ts
+++ b/src/__mocks__/mutiProfile.ts
@@ -1,0 +1,17 @@
+export const profileList = [
+  {
+    name: '쭈꾸미',
+    imageUrl:
+      'https://image.fmkorea.com/files/attach/new/20200822/3655109/2889212861/3050346954/8a72c1b35ac36f68c59bddc70b64db22.jpg',
+  },
+  {
+    name: '냥냥이',
+    imageUrl:
+      'https://t1.daumcdn.net/news/202009/22/xportsnews/20200922111443330clnu.jpg',
+  },
+  {
+    name: '야옹',
+    imageUrl:
+      'https://cphoto.asiae.co.kr/listimglink/6/2022022115112252412_1645423882.png',
+  },
+];

--- a/src/components/Chat/ChatList/index.tsx
+++ b/src/components/Chat/ChatList/index.tsx
@@ -33,10 +33,9 @@ export default function ChatList({
   const profileLen = profileList.length;
 
   const getProfileClassName = () => {
-    if (profileLen === 1) return 'single';
-    else if (profileLen === 2) return 'double';
+    if (profileLen === 2) return 'double';
     else if (profileLen === 3) return 'triple';
-    return 'single';
+    else return 'single';
   };
 
   const fetchChatRoom = () => {
@@ -44,12 +43,10 @@ export default function ChatList({
   };
   return (
     <li className={$['chat-list']} onClick={() => fetchChatRoom()}>
-      <div className={$['profile-info']}>
-        <ProfileImage
-          profileList={profileList}
-          className={getProfileClassName()}
-        />
-      </div>
+      <ProfileImage
+        profileList={profileList}
+        className={getProfileClassName()}
+      />
       <div className={$['chat-info']}>
         <div className={$['main-info']}>
           <strong>{title}</strong>

--- a/src/components/Chat/ChatList/index.tsx
+++ b/src/components/Chat/ChatList/index.tsx
@@ -1,9 +1,12 @@
 import $ from './style.module.scss';
-import ProfileImage from '../ProfileImage';
 import { useNavigate } from 'react-router-dom';
+import ProfileImage from 'src/components/ProfileImage';
 
 interface Props {
-  roomImage: string;
+  roomImage: {
+    name: string;
+    imageUrl: string;
+  }[];
   title: string;
   content: string;
   time: string;
@@ -18,12 +21,35 @@ export default function ChatList({
   count,
 }: Props) {
   const navigate = useNavigate();
+
+  const profileList = roomImage
+    .map(({ name, imageUrl }) => {
+      return {
+        altValue: name,
+        imageUrl: imageUrl,
+      };
+    })
+    .slice(0, 3);
+  const profileLen = profileList.length;
+
+  const getProfileClassName = () => {
+    if (profileLen === 1) return 'single';
+    else if (profileLen === 2) return 'double';
+    else if (profileLen === 3) return 'triple';
+    return 'single';
+  };
+
   const fetchChatRoom = () => {
     navigate('./room');
   };
   return (
     <li className={$['chat-list']} onClick={() => fetchChatRoom()}>
-      <ProfileImage altValue={title} imagePath={roomImage} />
+      <div className={$['profile-info']}>
+        <ProfileImage
+          profileList={profileList}
+          className={getProfileClassName()}
+        />
+      </div>
       <div className={$['chat-info']}>
         <div className={$['main-info']}>
           <strong>{title}</strong>

--- a/src/components/Chat/ChatList/style.module.scss
+++ b/src/components/Chat/ChatList/style.module.scss
@@ -6,19 +6,25 @@
   align-items: center;
   height: 70px;
   border-bottom: 1px solid $gray-250;
-  padding: 0 10px;
+  padding: 0 5px;
   cursor: pointer;
+
+  .profile-info {
+    margin: 5px;
+  }
 
   .chat-info {
     width: calc(100% - 45px);
     display: flex;
+    overflow: hidden;
 
     div {
       display: flex;
       flex-direction: column;
 
       &.main-info {
-        max-width: 60%;
+        max-width: 80%;
+
         strong {
           font-size: 16px;
           font-weight: 700;
@@ -33,6 +39,7 @@
 
       &.more-info {
         margin-left: auto;
+        margin-right: 0;
         align-items: flex-end;
         time {
           font-size: 14px;

--- a/src/components/Chat/ChatList/style.module.scss
+++ b/src/components/Chat/ChatList/style.module.scss
@@ -9,10 +9,6 @@
   padding: 0 5px;
   cursor: pointer;
 
-  .profile-info {
-    margin: 5px;
-  }
-
   .chat-info {
     width: calc(100% - 45px);
     display: flex;

--- a/src/components/Chat/ChatList/style.module.scss
+++ b/src/components/Chat/ChatList/style.module.scss
@@ -23,7 +23,7 @@
       flex-direction: column;
 
       &.main-info {
-        max-width: 80%;
+        max-width: 70%;
 
         strong {
           font-size: 16px;

--- a/src/components/Chat/ProfileImage/style.module.scss
+++ b/src/components/Chat/ProfileImage/style.module.scss
@@ -1,14 +1,17 @@
+@import 'src/styles/_color.scss';
 @import 'src/styles/_variables.scss';
 
 .profile-img {
-  width: 40px;
-  height: 40px;
+  width: 35px;
+  height: 35px;
   margin-right: 5px;
-  flex-shrink: 0;
+  border: 1px solid $gray-300;
+  border-radius: 50%;
+  overflow: hidden;
+
   img {
     width: 100%;
     height: 100%;
-    border-radius: 30px;
     object-fit: cover;
   }
 }

--- a/src/components/ProfileImage/index.tsx
+++ b/src/components/ProfileImage/index.tsx
@@ -1,0 +1,22 @@
+import $ from './style.module.scss';
+type ProfileInfo = {
+  altValue: string;
+  imageUrl: string;
+};
+
+interface Props {
+  profileList: ProfileInfo[];
+  className: string;
+}
+
+export default function ProfileImage({ profileList, className }: Props) {
+  return (
+    <div className={$[`${className}`]}>
+      {profileList.map(({ altValue, imageUrl }, index) => (
+        <div key={`${imageUrl}${index}`} className={$['personal-img']}>
+          <img src={imageUrl} alt={`${altValue}의 프로필 사진`} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ProfileImage/style.module.scss
+++ b/src/components/ProfileImage/style.module.scss
@@ -6,11 +6,12 @@
   position: relative;
   width: 50px;
   height: 50px;
+  margin: 5px;
+
   .personal-img {
     border: 1px solid $white;
     border-radius: 50%;
     overflow: hidden;
-
     img {
       width: 100%;
       height: 100%;

--- a/src/components/ProfileImage/style.module.scss
+++ b/src/components/ProfileImage/style.module.scss
@@ -1,0 +1,74 @@
+@import 'src/styles/_color.scss';
+
+.single,
+.double,
+.triple {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  .personal-img {
+    border: 1px solid $white;
+    border-radius: 50%;
+    overflow: hidden;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+}
+
+.single {
+  .personal-img {
+    display: flex;
+    border: 1px solid $gray-300;
+  }
+}
+
+.double {
+  .personal-img {
+    position: absolute;
+    display: flex;
+    width: calc(100% * (2 / 3));
+    width: calc(100% * (2 / 3));
+
+    @for $index from 1 through 2 {
+      &:nth-child(#{$index}) {
+        z-index: $index;
+        @if $index == 1 {
+          left: 0;
+        } @else if $index == 2 {
+          bottom: 0;
+          right: 0;
+        }
+      }
+    }
+  }
+}
+
+.triple {
+  display: flex;
+  justify-content: center;
+
+  .personal-img {
+    position: absolute;
+    width: 30px;
+    height: 30px;
+    z-index: 3;
+
+    @for $index from 1 through 3 {
+      &:nth-child(#{$index}) {
+        @if $index == 2 {
+          z-index: $index;
+          bottom: 0;
+          left: 0;
+        } @else if $index == 3 {
+          z-index: $index;
+          bottom: 0;
+          right: 0;
+        }
+      }
+    }
+  }
+}

--- a/src/pages/Chat/ChatList/index.tsx
+++ b/src/pages/Chat/ChatList/index.tsx
@@ -9,7 +9,7 @@ export default function ChatListPage() {
         {chatListMocks.map(
           ({ roomImage, title, content, time, count }, index) => (
             <ChatList
-              key={roomImage + index}
+              key={title + index}
               {...{ roomImage, title, content, time, count }}
             />
           )


### PR DESCRIPTION
## 💡 이슈
resolve #92

## 🤩 개요
채팅방 목록에 쓰일 단체 프로필 사진 기능에 대한 pr입니다.

## 🧑‍💻 작업 사항
- [ ] 하나의 프로필 사진 안에 1-3개까지 개인 프로필 사진을 넣음
- [ ] 각 프로필의 배치는 카카오톡과 비슷한 배치로 구현했습니다.

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
<img width="1094" alt="스크린샷 2022-07-07 오후 12 48 02" src="https://user-images.githubusercontent.com/63364990/177686541-c5eb1dca-756e-4150-acb6-87da1fc40349.png">
<img width="1094" alt="스크린샷 2022-07-07 오후 12 48 07" src="https://user-images.githubusercontent.com/63364990/177686552-0e8e5aaa-6073-428f-897c-10f9ed12afbc.png">
<img width="1094" alt="스크린샷 2022-07-07 오후 12 48 13" src="https://user-images.githubusercontent.com/63364990/177686556-cf13c73d-0332-41b2-81d5-32898e06f836.png">
- 아이폰 SE 화면
<img width="1094" alt="스크린샷 2022-07-07 오후 12 49 07" src="https://user-images.githubusercontent.com/63364990/177686606-64389fdf-58aa-4ce5-843c-34f93d328f99.png">

