### PR TITLE
[feat] 친구 삭제 페이지 마크업

### DIFF
--- a/src/__mocks__/friendMocks.ts
+++ b/src/__mocks__/friendMocks.ts
@@ -1,53 +1,66 @@
 const friendMocks = [
   {
+    id: 1,
     src: 'https://images.unsplash.com/photo-1618588507085-c79565432917?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8YmVhdXRpZnVsJTIwbmF0dXJlfGVufDB8fDB8fA%3D%3D&w=1000&q=80',
     name: '홍길동',
   },
   {
+    id: 2,
     src: 'https://media.istockphoto.com/photos/colorful-panoramic-mountain-view-at-sunrise-picture-id1129473522?b=1&k=20&m=1129473522&s=170667a&w=0&h=BUuwJYJXKx1nBZtKhddIFe0dfwJzeMyq7IcvSkewyOE=',
     name: '홍길동',
   },
   {
+    id: 3,
     src: 'https://dontgetserious.com/wp-content/uploads/2018/01/rose-day-hd-images.jpg',
     name: '홍길동',
   },
   {
+    id: 4,
     src: 'https://p4.wallpaperbetter.com/wallpaper/124/870/559/sunset-summer-sun-meadow-wallpaper-preview.jpg',
     name: '홍길동',
   },
   {
+    id: 5,
     src: 'https://media.istockphoto.com/photos/durdle-door-dorset-beach-picture-id501707966?b=1&k=20&m=501707966&s=170667a&w=0&h=-rpJ5XQM1xU0Qv4ZWKgcPYoZct_MBo40v3dDZDcWxVM=',
     name: '홍길동',
   },
   {
+    id: 6,
     src: 'https://i.pinimg.com/originals/86/8b/b1/868bb19abac2557a02ec28ca30f20ef5.jpg',
     name: '홍길동',
   },
   {
+    id: 7,
     src: 'https://images.all-free-download.com/images/graphicthumb/beautiful_scenic_01_hd_picture_166320.jpg',
     name: '홍길동',
   },
   {
+    id: 8,
     src: 'https://vistapointe.net/images/beautiful-2.jpg',
     name: '홍길동',
   },
   {
+    id: 9,
     src: 'https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/most-beautiful-places-in-the-us-sunflower-field-1578086404.jpg',
     name: '홍길동',
   },
   {
+    id: 10,
     src: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT9Gy4TWzXK9mthmZverUNaENrwD8TfoHvykQ&usqp=CAU',
     name: '홍길동',
   },
   {
+    id: 11,
     src: 'https://www.thegoodmorningpics.com/wp-content/uploads/2021/06/Beautiful-Good-Morning-Images-wallpaper-for-download-with-rising-sun-scenery.jpg',
     name: '홍길동',
   },
   {
+    id: 12,
     src: 'http://www.goodmorningimagesdownload.com/wp-content/uploads/2020/11/Nature-Whatsapp-DP-Profile-Images-Download-11.jpg',
     name: '홍길동',
   },
   {
+    id: 13,
     src: 'https://fiverr-res.cloudinary.com/images/q_auto,f_auto/gigs/157840933/original/2f67b312bd7cc34e6b23dbdcf603dc3daf293068/make-your-photos-beautiful-and-wonderful.jpg',
     name: '홍길동',
   },

--- a/src/components/FriendWithCheck/index.tsx
+++ b/src/components/FriendWithCheck/index.tsx
@@ -47,7 +47,7 @@ function FriendWithCheck({
     >
       <div className={$['left-box']}>
         <div className={$['img-wrapper']}>
-          <img alt={name + '프로필 이미지'} src={src} />
+          <img draggable={false} alt={name + '프로필 이미지'} src={src} />
         </div>
         <em>{name}</em>
       </div>

--- a/src/components/FriendWithCheck/index.tsx
+++ b/src/components/FriendWithCheck/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import cx from 'classnames';
 import {
   RiCheckboxCircleFill,
@@ -7,43 +7,18 @@ import {
 import $ from './style.module.scss';
 
 interface Props {
-  id: number;
+  isChecked: boolean;
   src: string;
   name: string;
   isVertical: boolean;
-  addSelectedFriends: (id: number) => void;
-  removeSelectedFriends: (id: number) => void;
-  padding?: number;
-  paddingLeft?: number;
+  onClick: () => void;
 }
 
-function FriendWithCheck({
-  id,
-  src,
-  name,
-  isVertical,
-  padding = 0,
-  paddingLeft = 0,
-  addSelectedFriends,
-  removeSelectedFriends,
-}: Props) {
-  const [isChecked, setIsChecked] = useState(false);
-
-  const handleCheck = () => {
-    if (isChecked) {
-      removeSelectedFriends(id);
-      setIsChecked(false);
-      return;
-    }
-    addSelectedFriends(id);
-    setIsChecked(true);
-  };
-
+function FriendWithCheck({ isChecked, src, name, isVertical, onClick }: Props) {
   return (
     <div
-      style={{ padding: `${padding}px`, paddingLeft: `${paddingLeft}px` }}
       className={cx($['friend'], { [$['vertical-shape']]: isVertical })}
-      onClick={handleCheck}
+      onClick={onClick}
     >
       <div className={$['left-box']}>
         <div className={$['img-wrapper']}>

--- a/src/components/FriendWithCheck/index.tsx
+++ b/src/components/FriendWithCheck/index.tsx
@@ -1,0 +1,63 @@
+import { memo, useState } from 'react';
+import cx from 'classnames';
+import {
+  RiCheckboxCircleFill,
+  RiCheckboxBlankCircleLine,
+} from 'react-icons/ri';
+import $ from './style.module.scss';
+
+interface Props {
+  id: number;
+  src: string;
+  name: string;
+  isVertical: boolean;
+  addSelectedFriends: (id: number) => void;
+  removeSelectedFriends: (id: number) => void;
+  padding?: number;
+  paddingLeft?: number;
+}
+
+function FriendWithCheck({
+  id,
+  src,
+  name,
+  isVertical,
+  padding = 0,
+  paddingLeft = 0,
+  addSelectedFriends,
+  removeSelectedFriends,
+}: Props) {
+  const [isChecked, setIsChecked] = useState(false);
+
+  const handleCheck = () => {
+    if (isChecked) {
+      removeSelectedFriends(id);
+      setIsChecked(false);
+      return;
+    }
+    addSelectedFriends(id);
+    setIsChecked(true);
+  };
+
+  return (
+    <div
+      style={{ padding: `${padding}px`, paddingLeft: `${paddingLeft}px` }}
+      className={cx($['friend'], { [$['vertical-shape']]: isVertical })}
+      onClick={handleCheck}
+    >
+      <div className={$['left-box']}>
+        <div className={$['img-wrapper']}>
+          <img alt={name + '프로필 이미지'} src={src} />
+        </div>
+        <em>{name}</em>
+      </div>
+      {isChecked ? (
+        <RiCheckboxCircleFill className={$['checked-icon']} />
+      ) : (
+        <RiCheckboxBlankCircleLine className={$['uncheck-icon']} />
+      )}
+    </div>
+  );
+}
+
+export default memo(FriendWithCheck);

--- a/src/components/FriendWithCheck/style.module.scss
+++ b/src/components/FriendWithCheck/style.module.scss
@@ -22,7 +22,6 @@
         border-radius: 50%;
         background-color: $gray-300;
         object-fit: contain;
-        -webkit-user-drag: none;
       }
     }
   }
@@ -42,7 +41,7 @@
   font-size: 14px;
 
   .img-wrapper {
-    margin: 0 0 8px 0;
+    margin-bottom: 8px;
 
     img {
       width: 65px;

--- a/src/components/FriendWithCheck/style.module.scss
+++ b/src/components/FriendWithCheck/style.module.scss
@@ -1,0 +1,52 @@
+@import 'src/styles/_color.scss';
+
+.friend {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+
+  .left-box {
+    display: flex;
+    align-items: center;
+
+    .img-wrapper {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-right: 10px;
+
+      img {
+        width: 50px;
+        height: 50px;
+        border-radius: 50%;
+        background-color: $gray-300;
+        object-fit: contain;
+        -webkit-user-drag: none;
+      }
+    }
+  }
+  .checked-icon {
+    font-size: 18px;
+    color: $primary;
+  }
+
+  .uncheck-icon {
+    font-size: 18px;
+    color: $gray-400;
+  }
+}
+
+.vertical-shape {
+  flex-direction: column;
+  font-size: 14px;
+
+  .img-wrapper {
+    margin: 0 0 8px 0;
+
+    img {
+      width: 65px;
+      height: 65px;
+    }
+  }
+}

--- a/src/components/FriendWithCheck/style.module.scss
+++ b/src/components/FriendWithCheck/style.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  padding: 10px;
   cursor: pointer;
 
   .left-box {

--- a/src/constants/headerMenus.tsx
+++ b/src/constants/headerMenus.tsx
@@ -61,6 +61,11 @@ const menusLeft: MenuType[] = [
     text: '홈',
     url: '/notice',
   },
+  {
+    icon: <IoChevronBack />,
+    text: '친구',
+    url: '/friends/delete',
+  },
 ];
 
 const menusRight: MenuType[] = [
@@ -92,6 +97,10 @@ const menusRight: MenuType[] = [
   {
     icon: <BsPersonDash />,
     url: '/friends',
+  },
+  {
+    text: '삭제',
+    url: '/friends/delete',
   },
   { text: '모두 삭제', url: '/notice' },
 ];

--- a/src/pages/Friends/Delete/index.tsx
+++ b/src/pages/Friends/Delete/index.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import FriendWithCheck from 'src/components/FriendWithCheck';
+import { PageLayout } from 'src/components/Layout';
+import Search from 'src/components/Search';
+import { friendMocks } from 'src/__mocks__/friendMocks';
+import $ from './style.module.scss';
+
+export default function DeleteFriends() {
+  const [selectedFriends, setSelectedFriends] = useState<number[]>([]);
+
+  useEffect(() => {
+    // API 연동 전 테스트
+    console.log(selectedFriends);
+  }, [selectedFriends]);
+
+  const addSelectedFriends = (id: number) =>
+    setSelectedFriends((pre) => [...pre, id]);
+
+  const removeSelectedFriends = (id: number) =>
+    setSelectedFriends((pre) => pre.filter((value) => value !== id));
+
+  return (
+    <PageLayout isNeedFooter headerHeight={44}>
+      <div className={$['search-box']}>
+        <Search />
+      </div>
+      <ul>
+        {friendMocks.map(({ src, name, id }) => (
+          <li key={id} className={$['friend-bar']}>
+            <FriendWithCheck
+              {...{ id, src, name, addSelectedFriends, removeSelectedFriends }}
+              isVertical={false}
+              padding={10}
+              paddingLeft={10}
+            />
+          </li>
+        ))}
+      </ul>
+    </PageLayout>
+  );
+}

--- a/src/pages/Friends/Delete/index.tsx
+++ b/src/pages/Friends/Delete/index.tsx
@@ -31,7 +31,6 @@ export default function DeleteFriends() {
               {...{ id, src, name, addSelectedFriends, removeSelectedFriends }}
               isVertical={false}
               padding={10}
-              paddingLeft={10}
             />
           </li>
         ))}

--- a/src/pages/Friends/Delete/index.tsx
+++ b/src/pages/Friends/Delete/index.tsx
@@ -13,11 +13,14 @@ export default function DeleteFriends() {
     console.log(selectedFriends);
   }, [selectedFriends]);
 
-  const addSelectedFriends = (id: number) =>
-    setSelectedFriends((pre) => [...pre, id]);
-
-  const removeSelectedFriends = (id: number) =>
-    setSelectedFriends((pre) => pre.filter((value) => value !== id));
+  const handleClick = (targetId: number) => {
+    const isExists = selectedFriends.includes(targetId);
+    if (isExists) {
+      setSelectedFriends((pre) => pre.filter((id) => id !== targetId));
+      return;
+    }
+    setSelectedFriends((pre) => [...pre, targetId]);
+  };
 
   return (
     <PageLayout isNeedFooter headerHeight={44}>
@@ -28,9 +31,10 @@ export default function DeleteFriends() {
         {friendMocks.map(({ src, name, id }) => (
           <li key={id} className={$['friend-bar']}>
             <FriendWithCheck
-              {...{ id, src, name, addSelectedFriends, removeSelectedFriends }}
+              isChecked={selectedFriends.includes(id)}
               isVertical={false}
-              padding={10}
+              onClick={() => handleClick(id)}
+              {...{ src, name }}
             />
           </li>
         ))}

--- a/src/pages/Friends/Delete/style.module.scss
+++ b/src/pages/Friends/Delete/style.module.scss
@@ -1,0 +1,15 @@
+@import '/src/styles/color';
+@import '/src/styles/mixin';
+
+.search-box {
+  padding: 10px;
+}
+
+.friend-bar {
+  border-top: 1px solid $gray-200;
+
+  &:last-child {
+    margin-bottom: 100px;
+    border-bottom: 1px solid $gray-200;
+  }
+}

--- a/src/pages/Friends/index.ts
+++ b/src/pages/Friends/index.ts
@@ -1,2 +1,3 @@
 export { default as Friends } from './main';
 export { default as FriendsDetail } from './detail';
+export { default as DeleteFriends } from './Delete';

--- a/src/routes/FriendsRouter.tsx
+++ b/src/routes/FriendsRouter.tsx
@@ -1,11 +1,12 @@
 import { Routes, Route } from 'react-router-dom';
-import { Friends, FriendsDetail } from 'src/pages/Friends';
+import { DeleteFriends, Friends, FriendsDetail } from 'src/pages/Friends';
 
 function FriendsRouter() {
   return (
     <Routes>
       <Route index element={<Friends />} />
       <Route path="detail" element={<FriendsDetail />} />
+      <Route path="delete" element={<DeleteFriends />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## 💡 이슈
resolve #101

## 🤩 개요
디자인 가이드에 따라 친구 삭제 페이지를 마크업했습니다.

## 🧑‍💻 작업 사항
- `friends/delete` 경로 라우팅 & 헤더 constants 추가
- `DeleteFriends` 컴포넌트 구현
- 목록에서 삭제하려는 친구를 선택할 수 있는 기능 구현

## 📖 참고 사항
- 선택 목록을 만들 때 고유한 값을 사용하기 위해서 `FriendMocks`에 `id` 속성을 추가했습니다.
- 친구 선택 기능을 만들기 위해서는 체크 상태와 아이콘을 추가하고 핸들러를 부모 컴포넌트로부터 받아와야 합니다. 이를 기존 `Friends` 컴포넌트에 넣기에는 코드가 복잡해질 것 같아 `FriendsWithCheck`라는 컴포넌트를 별도로 만들었습니다.
![스크린샷 2022-08-02 오후 1 53 27](https://user-images.githubusercontent.com/71015915/182295651-ffae28f2-b832-4a89-92e6-856ebe0434fa.png)
![delete_friends_demo](https://user-images.githubusercontent.com/71015915/182295668-66120d34-ecb7-487d-b152-a88f9ade1da4.gif)
