### PR TITLE
feat : textarea 자동 조절

### DIFF
--- a/src/components/Chat/MessageInput/index.tsx
+++ b/src/components/Chat/MessageInput/index.tsx
@@ -1,14 +1,50 @@
-import { memo } from 'react';
+import { memo, useCallback, useRef, useState } from 'react';
 import $ from './style.module.scss';
+// import ContentBox from 'src/components/ContentBox';
+import useAutoHeightChange from 'src/hooks/useAutoHeightChange';
+import { IoSend, IoImages } from 'react-icons/io5';
 
 export function MessageInput() {
+  const [newContent, setNewContent] = useState('');
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const handleContentChange = useCallback(() => {
+    const textareaRef = contentRef.current;
+    const DivContent = parentRef.current;
+    if (textareaRef && DivContent) {
+      if (textareaRef.scrollHeight <= 100) {
+        const scrollHeight = useAutoHeightChange(contentRef);
+
+        if (scrollHeight) {
+          DivContent.style.height = 'auto';
+          DivContent.style.height = `${scrollHeight + 12}px`;
+        }
+      }
+    }
+  }, []);
+
   return (
-    <div className={$['message-input-box']}>
-      <button type="button">+</button>
-      <div className={$.text}>
-        <textarea name="message" id=""></textarea>
+    <div className={$['message-input-box']} ref={parentRef}>
+      <div className={$['img-btn']}>
+        <button type="button">
+          <IoImages />
+        </button>
       </div>
-      <button type="submit">전송</button>
+      <div className={$.text}>
+        <textarea
+          name="message"
+          id=""
+          defaultValue={newContent}
+          placeholder="메세지 보내기..."
+          ref={contentRef}
+          onChange={handleContentChange}
+          autoFocus
+        />
+      </div>
+      <button type="submit">
+        <IoSend />
+      </button>
     </div>
   );
 }

--- a/src/components/Chat/MessageInput/style.module.scss
+++ b/src/components/Chat/MessageInput/style.module.scss
@@ -3,31 +3,38 @@
 
 .message-input-box {
   display: flex;
-  height: 30px;
-  padding: 5px;
+  align-items: center;
   border: 1px solid $gray-300;
-  border-radius: 10px;
-  button[type='button'] {
-    @include button(30px, none, $primary, $white, 20px, 30px);
+  border-radius: 22px;
+  height: 44px;
+  padding: 0 10px;
+  font-size: 100%;
+  overflow-y: hidden;
+
+  .img-btn {
+    button[type='button'] {
+      display: flex;
+      color: $black-100;
+      font-size: 20px;
+    }
   }
+
   .text {
     display: flex;
-    flex-direction: column;
     flex: 1 1 auto;
+    flex-direction: column;
+    justify-content: center;
+    padding: 0 10px;
+    // height: 22px;
     textarea {
-      border: none;
+      height: 22px;
       overflow: auto;
-      padding: 8px;
-      resize: none;
-      &:focus {
-        outline: none;
-      }
-      &::-webkit-scrollbar {
-        display: none;
-      }
+      font-size: 13px;
+      // line-height: 22px;
     }
   }
   button[type='submit'] {
-    @include button(40px, none, $primary, $white, 14px, 30px);
+    color: $black-100;
+    font-size: 20px;
   }
 }

--- a/src/hooks/useAutoHeightChange.ts
+++ b/src/hooks/useAutoHeightChange.ts
@@ -1,0 +1,11 @@
+export default function useAutoHeightChange(
+  contentRef: React.MutableRefObject<HTMLTextAreaElement | null>
+) {
+  const textareaContent = contentRef.current;
+  if (textareaContent) {
+    textareaContent.style.height = 'auto';
+    textareaContent.style.height = `${textareaContent.scrollHeight}px`;
+
+    return textareaContent.scrollHeight;
+  }
+}


### PR DESCRIPTION
## 💡 이슈
resolve #111

## 🤩 개요
채팅방 MessageInput의 textarea height 자동 조절 기능을 추가했습니다.

## 🧑‍💻 작업 사항
- 동용님이 만들어주신 ContentBox가 height와 padding이 채팅방 messageInput으로 사용하기에 스타일이 안맞음 -> height와 padding을 props로 전달하는 방식으로 변경해보았으나 ⬇️
- 채팅방 messageInput같은 경우 textarea의 heigth가 늘어남에 따라 상위의 div의 height도 같이 늘어나야 하기때문에, 자동 조절 함수가 따로 필요할 것 같습니다.
- 따라서, `useAutoHeightChange`으로 hook으로 빼고, 직접 textarea에 적용시키는 방식으로 구현했습니다.
![스크린샷 2022-08-20 오후 3 15 56](https://user-images.githubusercontent.com/63364990/185731823-cce66b29-7acf-44b4-9f79-c359f2ee609c.png)

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
- ⚠️ 이슈1 : `textarea`의 `placeholder` 위치를 센터로 맞추기 위해서 `line-height`를 사용하면 `첫줄을 입력했을때`, textarea의 `scrollHeight`가 기존보다 2배로 늘어납니다.
- ⚠️ 이슈2 : 텍스트를 썼다가 지웠을 경우 line-height가 적용이 안돼서 센터로 맞춰지지 않음
- `line-height` 적용 전
![화면 기록 2022-08-20 오후 3 28 49](https://user-images.githubusercontent.com/63364990/185732219-71595023-6482-4665-99c7-cf100779c10c.gif)

- `line-height` 적용 후
![화면 기록 2022-08-20 오후 3 26 54](https://user-images.githubusercontent.com/63364990/185732194-2b8d7d54-70fc-4039-bf22-9460fa7c34f0.gif)

