### PR TITLE
[feat] 친구 추가 페이지 마크업

### DIFF
--- a/src/constants/headerMenus.tsx
+++ b/src/constants/headerMenus.tsx
@@ -66,6 +66,11 @@ const menusLeft: MenuType[] = [
     text: '친구',
     url: '/friends/delete',
   },
+  {
+    icon: <IoChevronBack />,
+    text: '친구 찾기',
+    url: '/friends/add',
+  },
 ];
 
 const menusRight: MenuType[] = [
@@ -103,6 +108,10 @@ const menusRight: MenuType[] = [
     url: '/friends/delete',
   },
   { text: '모두 삭제', url: '/notice' },
+  {
+    text: '추가',
+    url: '/friends/add',
+  },
 ];
 
 export default [menusLeft, menusRight];

--- a/src/pages/Friends/Add/index.tsx
+++ b/src/pages/Friends/Add/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import FriendWithCheck from 'src/components/FriendWithCheck';
+import { PageLayout } from 'src/components/Layout';
+import Search from 'src/components/Search';
+import { friendMocks } from 'src/__mocks__/friendMocks';
+import $ from './style.module.scss';
+
+export default function AddFriends() {
+  const [selectedFriends, setSelectedFriends] = useState<number[]>([]);
+
+  useEffect(() => {
+    // API 연동 전 테스트
+    console.log(selectedFriends);
+  }, [selectedFriends]);
+
+  const handleClick = (targetId: number) => {
+    const isExists = selectedFriends.includes(targetId);
+    if (isExists) {
+      setSelectedFriends((pre) => pre.filter((id) => id !== targetId));
+      return;
+    }
+    setSelectedFriends((pre) => [...pre, targetId]);
+  };
+
+  return (
+    <PageLayout isNeedFooter headerHeight={44}>
+      <div className={$['search-box']}>
+        <Search />
+      </div>
+      <ul>
+        {friendMocks.map(({ src, name, id }) => (
+          <li key={id} className={$['friend-bar']}>
+            <FriendWithCheck
+              isChecked={selectedFriends.includes(id)}
+              isVertical={false}
+              onClick={() => handleClick(id)}
+              {...{ src, name }}
+            />
+          </li>
+        ))}
+      </ul>
+    </PageLayout>
+  );
+}

--- a/src/pages/Friends/Add/style.module.scss
+++ b/src/pages/Friends/Add/style.module.scss
@@ -1,0 +1,15 @@
+@import '/src/styles/color';
+@import '/src/styles/mixin';
+
+.search-box {
+  padding: 10px;
+}
+
+.friend-bar {
+  border-top: 1px solid $gray-200;
+
+  &:last-child {
+    margin-bottom: 100px;
+    border-bottom: 1px solid $gray-200;
+  }
+}

--- a/src/pages/Friends/index.ts
+++ b/src/pages/Friends/index.ts
@@ -1,3 +1,4 @@
 export { default as Friends } from './main';
 export { default as FriendsDetail } from './detail';
 export { default as DeleteFriends } from './Delete';
+export { default as AddFriends } from './Add';

--- a/src/routes/FriendsRouter.tsx
+++ b/src/routes/FriendsRouter.tsx
@@ -1,5 +1,10 @@
 import { Routes, Route } from 'react-router-dom';
-import { DeleteFriends, Friends, FriendsDetail } from 'src/pages/Friends';
+import {
+  DeleteFriends,
+  Friends,
+  FriendsDetail,
+  AddFriends,
+} from 'src/pages/Friends';
 
 function FriendsRouter() {
   return (
@@ -7,6 +12,7 @@ function FriendsRouter() {
       <Route index element={<Friends />} />
       <Route path="detail" element={<FriendsDetail />} />
       <Route path="delete" element={<DeleteFriends />} />
+      <Route path="add" element={<AddFriends />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## 💡 이슈
resolve #100

## 🤩 개요
친구 추가 페이지를 마크업했습니다.

## 🧑‍💻 작업 사항
- [x] 친구 추가 페이지 `/friends/add` 경로로 라우팅.
- [x] 헤더 constant에 친구 추가 페이지 헤더 생성.
- [x] 친구 추가 페이지 마크업.

## 📖 참고 사항
- 페이지의 구조는 친구 삭제 페이지와 동일하나, 나중에 API를 붙이고 페이지별 세부 설정을 했을 때 컴포넌트가 너무 복잡해질 것 같아 별도의 컴포넌트로 분리했습니다.
- 다른 PR에서 페이지 템플릿으로 묶는 작업을 하겠습니다~

<img width="312" alt="image" src="https://user-images.githubusercontent.com/71015915/185733374-183ef1ca-4963-4f21-b1ac-e5b9134dad5a.png">