### PR TITLE
설정 페이지 배경색과 설정 메뉴 배경색 변경

### DIFF
--- a/src/components/Setting/Container/style.module.scss
+++ b/src/components/Setting/Container/style.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   height: 50px;
-  background-color: $gray-200;
+  background-color: $white;
 }
 
 .single-bar {
@@ -19,11 +19,11 @@
 
 .middle-bar {
   @include bar();
-  border-top: 2px solid $white;
+  border-top: 2px solid $gray-50;
 }
 
 .bottom-bar {
   @include bar();
-  border-top: 2px solid $white;
+  border-top: 2px solid $gray-50;
   border-radius: 0 0 10px 10px;
 }

--- a/src/components/Setting/SettingBox/style.module.scss
+++ b/src/components/Setting/SettingBox/style.module.scss
@@ -1,7 +1,9 @@
 @import '/src/styles/color';
 
 .container {
-  padding: 15px;
+  height: calc(100vh - 44px);
+  padding: 0 15px;
+  background-color: $gray-50;
 
   .title {
     margin: 25px 0 20px;


### PR DESCRIPTION
## 💡 이슈
resolve #125

## 🤩 개요
내 정보 페이지의 색깔과 통일감을 주기 위해 설정 페이지의 샐깔을 수정했습니다.

## 🧑‍💻 작업 사항
- `/setting` 페이지의 배경색을 `gray-50`으로 변경.
- 세팅 메뉴의 배경색과 구분선을 `white`로 변경.

## 📖 참고 사항

- PR의 크기가 작기 때문에 셀프 머지 하겠습니다~
<img width="388" alt="image" src="https://user-images.githubusercontent.com/71015915/187729008-4c5260c2-6029-4e9a-ada1-26058d1e434e.png">
