### PR TITLE
[Fix] 화면 세로 길이가 짧은 기기에서 내 정보 페이지 배경이 깨지는 문제 수정

### DIFF
--- a/src/components/MyPage/CardBox/style.module.scss
+++ b/src/components/MyPage/CardBox/style.module.scss
@@ -2,7 +2,7 @@
 @import '/src/styles/mixin';
 
 .container {
-  height: calc(100vh - 99px);
+  min-height: calc(100vh - 99px);
   padding: 0 20px;
   background-color: $gray-50;
 


### PR DESCRIPTION
## 💡 이슈
resolve #201

## 🤩 개요
화면 세로 길이가 짧은 기기에서 내 정보 페이지에 접속하면 스크롤 시 밑부분의 배경색이 잘리는 문제를 수정했습니다.

## 🧑‍💻 작업 사항
`height`로 설정되어 있던 배경색 컨테이너의 높이를 `min-height`로 변경.

## 📖 참고 사항
셀프 머지 하겠습니다~